### PR TITLE
Add install_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,5 +82,10 @@ setup(name = 'requestbuilder',
                      'Programming Language :: Python :: 2.6',
                      'Programming Language :: Python :: 2.7',
                      'Topic :: Internet'],
+      install_requires=[
+          "requests",
+          "argparse",
+          "six",
+      ],
       cmdclass = {'build_py': build_py_with_git_version,
                   'sdist': sdist_with_git_version})


### PR DESCRIPTION
This package requires (at least) argparse, six, and requests, so setup.py needs to pull those in.  Otherwise, installing requestbuilder from pypi doesn't result in a functional environment.
