### PR TITLE
No ParseError in python 2.6 xml module

### DIFF
--- a/requestbuilder/xmlparse.py
+++ b/requestbuilder/xmlparse.py
@@ -20,6 +20,11 @@ try:
 except ImportError:
     from xml.etree import ElementTree
 
+try:
+    from xml.etree.ElementTree import ParseError
+except ImportError:
+    from xml.parsers.expat import ExpatError as ParseError
+
 
 def parse_aws_xml(xml_stream, list_item_tags=None):
     '''
@@ -89,7 +94,7 @@ def parse_aws_xml(xml_stream, list_item_tags=None):
                         stack[-2][1][tag] = stack[-1][1]
                 stack.pop()
                 elem.clear()  # free up some memory
-    except ElementTree.ParseError:
+    except (ParseError, SyntaxError):
         raise ValueError('XML parse error')
     return stack[0][1]
 
@@ -167,7 +172,7 @@ def parse_listdelimited_aws_xml(xml_stream, list_tags=None):
                         stack[-2][1][tag] = stack[-1][1]
                 stack.pop()
                 elem.clear()  # free up some memory
-    except ElementTree.ParseError:
+    except (ParseError, SyntaxError):
         raise ValueError('XML parse error')
     return stack[0][1]
 


### PR DESCRIPTION
In python 2.6, the exception class ElementTree.ParseError does not
exist. Instead the ExpatError exception is thrown. Also, the parser
might throw a SyntaxError exception. While the ParseError exception
inherits from SyntaxError, the ExpatError exception does not. In order
to fix the issue we import ExpatError only if there is no ParseError
class available and name it ParseError. When catching exceptions we
catch both ParseError and SyntaxError. Since ParseError could be an
ExpatError and may not inherit from SyntaxError, we need to explicitly
catch Syntax Error exceptions.
